### PR TITLE
CI: safe-chain導入とビルド手順の分離

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -30,8 +30,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      - name: Install dependencies
+        run: npm ci
       - name: build
-        run: npm ci && npm run build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## 概要
GitHub Actions の Pages ワークフローに safe-chain を導入しました。

## 変更内容
- `npm ci` の前に safe-chain のインストール手順を追加
- `npm ci && npm run build` を分離し、以下の3ステップに整理
  - Install safe-chain
  - Install dependencies (`npm ci`)
  - build (`npm run build`)

## 影響範囲
- `.github/workflows/gh_pages.yml` のみ（CI ワークフロー変更のみ）
- 依存関係やライブラリのバージョン更新はなし

## 確認
- ワークフローファイル差分を確認済み
- マージ後に GitHub Actions の実行結果を確認予定
