### PR TITLE
chore: .npmrc に min-release-age=2880（2日）を設定

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2880


### PR DESCRIPTION
## 概要
- `.npmrc` に `min-release-age=2880`（2日）を追加しました。

## 目的
- 公開直後のnpmパッケージを即時導入しないようにし、サプライチェーンリスクを下げるためです。

## 変更内容
- `min-release-age=2880` を設定

## 確認
- 設定追加のみのため、テストは未実施です。
