### PR TITLE
chore: TypeScriptを6系へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.3.4",
         "react-cookie": "^4.1.1",
-        "typescript": "^5.0.2",
+        "typescript": "^6.0.2",
         "vite": "^4.3.2",
         "vite-plugin-singlefile": "^0.13.5",
         "vitest": "^0.30.1"
@@ -3916,9 +3916,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
     "react-cookie": "^4.1.1",
-    "typescript": "^5.0.2",
+    "typescript": "^6.0.2",
     "vite": "^4.3.2",
     "vite-plugin-singlefile": "^0.13.5",
     "vitest": "^0.30.1"


### PR DESCRIPTION
## 概要
- `typescript` を `^5.0.2` から `^6.0.2` に更新しました（semver範囲外のメジャー更新）。

## 変更内容
- `package.json` の `typescript` バージョンを更新
- `package-lock.json` を更新

## 事前確認（変更ログ / Breaking Changes）
- リリースノート: https://github.com/microsoft/TypeScript/releases/tag/v6.0.2
- 公式アナウンス: https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/
- API Breaking Changes: https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes

上記を確認し、このリポジトリ（フロントエンドアプリ）では TypeScript Compiler API を直接利用していないため、主な影響は型チェック挙動の変化に限定される想定です。

## 検証
- `npm test -- --run --passWithNoTests`
  - テストファイル未配置のため `No test files found, exiting with code 0`
- `npm run build`
  - 成功（`tsc && vite build`）

## 備考
- メジャー更新は「1依存関係につき1PR」の方針に従っています。
