### PR TITLE
chore: i18nextを26系へ更新

### DIFF
--- a/.pr_body_i18next26.md
+++ b/.pr_body_i18next26.md
@@ -1,0 +1,27 @@
+## 概要
+- `i18next` を `^22.5.1` から `^26.0.7` へ更新しました（semver範囲外のメジャー更新）。
+
+## 変更内容
+- `package.json` の `i18next` バージョンを更新
+- `package-lock.json` を更新
+
+## 変更ログ / Breaking Changes 確認
+- Migration Guide: https://www.i18next.com/misc/migration-guide
+- Releases: https://github.com/i18next/i18next/releases
+
+確認した主な破壊的変更:
+- `interpolation.format` の旧API削除
+- `initImmediate` 廃止（`initAsync` を使用）
+- `showSupportNotice` 関連オプション削除
+
+このリポジトリでは `src/i18n/configs.ts` で上記の削除対象APIを使用していないため、今回の利用範囲では影響は限定的と判断しました。
+
+## 検証
+- `npm test -- --run --passWithNoTests`
+  - テストファイル未配置のため `No test files found, exiting with code 0`
+- `npm run build`
+  - 成功
+
+## 備考
+- メジャー更新は「1依存関係につき1PR」の方針に従っています。
+- GitHub Actions は `main` への push 後に Pages ビルドが動く構成のため、マージ後に CI 成功を確認します。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chromatic_clans",
       "version": "0.0.0",
       "dependencies": {
-        "i18next": "^22.5.1",
+        "i18next": "^26.0.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^12.3.1"
@@ -2760,26 +2760,31 @@
       }
     },
     "node_modules/i18next": {
-      "version": "22.5.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.5.1.tgz",
-      "integrity": "sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==",
+      "version": "26.0.7",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.7.tgz",
+      "integrity": "sha512-f7tL/iw0VQsx4nC5oNxBM2RjM8alNys5KzyiQTU6A9TI5TI89py4/Ez1cKFvHiLWsvzOXvuGUES+Kk/A2WiANQ==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.6"
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {
@@ -3919,7 +3924,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "i18next": "^22.5.1",
+    "i18next": "^26.0.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^12.3.1"


### PR DESCRIPTION
## 概要
- `i18next` を `^22.5.1` から `^26.0.7` へ更新しました（semver範囲外のメジャー更新）。

## 変更内容
- `package.json` の `i18next` バージョンを更新
- `package-lock.json` を更新

## 変更ログ / Breaking Changes 確認
- Migration Guide: https://www.i18next.com/misc/migration-guide
- Releases: https://github.com/i18next/i18next/releases

確認した主な破壊的変更:
- `interpolation.format` の旧API削除
- `initImmediate` 廃止（`initAsync` を使用）
- `showSupportNotice` 関連オプション削除

このリポジトリでは `src/i18n/configs.ts` で上記の削除対象APIを使用していないため、今回の利用範囲では影響は限定的と判断しました。

## 検証
- `npm test -- --run --passWithNoTests`
  - テストファイル未配置のため `No test files found, exiting with code 0`
- `npm run build`
  - 成功

## 備考
- メジャー更新は「1依存関係につき1PR」の方針に従っています。
- GitHub Actions は `main` への push 後に Pages ビルドが動く構成のため、マージ後に CI 成功を確認します。
