### PR TITLE
chore: Pages workflow の Node.js を 24 に更新

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 16
+          node-version: 24
       - name: Install safe-chain
         run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
       - name: Install dependencies


### PR DESCRIPTION
## 概要
- GitHub Pages workflow の Node.js を `16` から `24` に更新
- Vite 8 の要件を満たす Node 系へ引き上げ

## 背景
- main への merge 後、Pages deploy が `node-version: 16` のままで失敗していた
- `Vite requires Node.js 20.19+ or 22.12+` が直接の失敗理由だった

## 変更内容
- `.github/workflows/gh_pages.yml`
  - `actions/setup-node` の `node-version` を `24` に変更

## 確認
- workflow 差分を確認
- 既存のローカル build 成功実績あり