### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,30 @@
 version: 2
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    patterns:
+      - "*"
     cooldown:
       default-days: 2
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    multi-ecosystem-group: "dependency-updates"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    multi-ecosystem-group: "dependency-updates"


### PR DESCRIPTION
### Motivation
- Dependabot の更新を可能な限りグルーピングして PR ノイズを減らすために、複数エコシステムをまとめる設定を追加しました。 

### Description
- `.github/dependabot.yml` に `multi-ecosystem-groups.dependency-updates` を追加し週次スケジュールを指定しました. 
- `npm` と `github-actions` の `updates` エントリにワイルドカードの `patterns: ["*"]` を追加してまとめ対象としています. 
- `all-npm-security-updates` と `all-github-actions-security-updates` のセキュリティ専用グループを追加してセキュリティ更新をまとめています. 
- 既存の `npm` の `cooldown.default-days: 2` は維持し、両エコシステムを `multi-ecosystem-group: "dependency-updates"` に紐付けています. 

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data["multi-ecosystem-groups"]; abort("bad updates") unless data["updates"].is_a?(Array) && data["updates"].size == 2; puts "dependabot.yml is valid YAML"'` を実行して成功しました。 
- `git diff --check` を実行して差分チェックは問題ありませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b77256e08326bd7fa858ab8c25a0)