### PR TITLE
npmレジストリ設定を追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=2880
+registry=https://npm.flatt.tech


### PR DESCRIPTION
### Motivation
- プロジェクトのnpm取得先を指定のレジストリに切り替えるため、`.npmrc`にレジストリ設定を追加するためです。

### Description
- `.npmrc` に `registry=https://npm.flatt.tech` を追記し、既存の `min-release-age=2880` 行は維持しました。 
- 変更は `.npmrc` の1行追加のみです。

### Testing
- 自動差分チェックとして `git diff --check` を実行し問題がないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0442e83c38832691043cb90eb944f8)