### PR TITLE
Dependabot設定を更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,34 @@
 version: 2
-multi-ecosystem-groups:
-  dependency-updates:
-    schedule:
-      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    patterns:
-      - "*"
     cooldown:
-      default-days: 2
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-npm-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-    multi-ecosystem-group: "dependency-updates"
+
   - package-ecosystem: "github-actions"
     directory: "/"
-    patterns:
-      - "*"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-github-actions-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-    multi-ecosystem-group: "dependency-updates"


### PR DESCRIPTION
### Motivation
- 既存のDependabot設定を参考設定に合わせて整理し、不要なノイズとなる頻繁なminor/patchの自動PRを抑制するためです。
- 重要なセキュリティ更新は見逃さないようエコシステム別にグループ化するためです。
- npmの更新頻度調整とマジョール更新のクールダウンを導入して運用負荷を下げるためです。

### Description
- ファイル `./.github/dependabot.yml` を更新し、`updates` セクションを明示的に定義しました。
- `npm` と `github-actions` を週次スケジュールに設定し、両方に `ignore` ルールで `version-update:semver-minor` と `version-update:semver-patch` を無視するよう追加しました。
- `npm` に対して `cooldown` を追加し、`default-days: 7` と `semver-major-days: 60` を設定しました。
- 各エコシステムのセキュリティ更新をグループ (`all-npm-security-updates` / `all-github-actions-security-updates`) にまとめました。

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); raise unless data["version"] == 2 && data["updates"].length == 2; puts "dependabot.yml OK"'` を実行して成功しました。
- `git diff --check` を実行して問題ないことを確認しました。
- `python3` での `yaml.safe_load` チェックを試行しましたが、環境に `PyYAML` がないため実行できませんでした（未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b21c22c8c832686d1af87b1ec32cf)